### PR TITLE
bootstrap UI test structure

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -32,18 +32,44 @@ pipeline:
       - php occ a:e search_elastic
       - php occ a:e testing
       - php occ a:l
+      - php occ config:system:set trusted_domains 1 --value=owncloud
+      - php occ log:manage --level 0
+
+  owncloud-log:
+    image: owncloud/ubuntu:16.04
+    detach: true
+    pull: true
+    commands:
+      - tail -f /var/www/owncloud/data/owncloud.log
+
+  configure-app:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - cd /var/www/owncloud/
+      - php occ config:app:set search_elastic servers --value elasticsearch
+      - php occ search:reset
+    when:
+      matrix:
+        NEED_ELASTICSEARCH_SERVER: true
 
   test-php-lint:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     commands:
       - make test-php-lint
+    when:
+      matrix:
+        TEST_SUITE: php
 
   phpunit-unit-tests:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     commands:
       - make test-php-unit-dbg
+    when:
+      matrix:
+        TEST_SUITE: php
 
   scrutinizer:
     image: owncloudci/php:${PHP_VERSION}
@@ -51,6 +77,50 @@ pipeline:
     commands:
       - wget -q https://scrutinizer-ci.com/ocular.phar
       - php ocular.phar code-coverage:upload --access-token=c014f674b55be0d0e39f63523623cae5f33cebba1f95846e84bdbedeed3e43c6  --format=php-clover tests/unit/clover.xml
+    when:
+      matrix:
+        TEST_SUITE: php
+
+  fix-permissions:
+    image: owncloudci/php:${PHP_VERSION}
+    commands:
+      - chown www-data /var/www/owncloud -R
+      - chmod 777 /var/www/owncloud/tests/acceptance/filesForUpload -R
+      - cd /var/www/owncloud/tests/acceptance
+      - chmod +x run.sh
+    when:
+      matrix:
+        TEST_SUITE: acceptance
+
+  webui-acceptance-tests:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    environment:
+      - BROWSER=chrome
+      - SELENIUM_HOST=selenium
+      - TEST_SERVER_URL=http://owncloud
+      - SELENIUM_PORT=4444
+      - PLATFORM=Linux
+      - BEHAT_SUITE=${BEHAT_SUITE}
+    commands:
+      - cd /var/www/owncloud/tests/acceptance
+      - ./run.sh --remote --config /var/www/owncloud/apps/search_elastic/tests/acceptance/config/behat.yml
+    when:
+      matrix:
+        BEHAT_SUITE: webUISearchElastic
+
+  api-acceptance-tests:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    environment:
+      - TEST_SERVER_URL=http://owncloud
+      - BEHAT_SUITE=${BEHAT_SUITE}
+    commands:
+      - cd /var/www/owncloud/tests/acceptance
+      - ./run.sh --remote --config /var/www/owncloud/apps/search_elastic/tests/acceptance/config/behat.yml
+    when:
+      matrix:
+        BEHAT_SUITE: apiSearchElastic
 
   notify:
     image: plugins/slack:1
@@ -105,24 +175,50 @@ services:
       matrix:
         DB_TYPE: pgsql
 
+  elasticsearch:
+    image: owncloudci/elasticsearch
+    when:
+      matrix:
+        NEED_ELASTICSEARCH_SERVER: true
+
+  owncloud:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    environment:
+      - APACHE_WEBROOT=/var/www/owncloud/
+    command: [ "/usr/local/bin/apachectl", "-e", "debug", "-D", "FOREGROUND" ]
+    when:
+      matrix:
+        NEED_SERVER: true
+
+  selenium:
+    image: selenium/standalone-chrome-debug:latest
+    pull: true
+    when:
+      matrix:
+        BEHAT_SUITE: webUISearchElastic
 matrix:
   include:
-    # unit tests
+    # lint & unit tests
      - PHP_VERSION: 5.6
        OC_VERSION: daily-stable10-qa
        DB_TYPE: sqlite
+       TEST_SUITE: php
 
      - PHP_VERSION: 7.0
        OC_VERSION: daily-stable10-qa
        DB_TYPE: sqlite
+       TEST_SUITE: php
 
      - PHP_VERSION: 7.1
        OC_VERSION: daily-stable10-qa
        DB_TYPE: sqlite
+       TEST_SUITE: php
 
      - PHP_VERSION: 7.2
        OC_VERSION: daily-stable10-qa
        DB_TYPE: sqlite
+       TEST_SUITE: php
 
      - PHP_VERSION: 7.1
        OC_VERSION: daily-stable10-qa
@@ -131,6 +227,7 @@ matrix:
        DB_NAME: oc_db
        DB_USERNAME: admin
        DB_PASSWORD: secret
+       TEST_SUITE: php
 
      - PHP_VERSION: 7.1
        OC_VERSION: daily-stable10-qa
@@ -138,6 +235,7 @@ matrix:
        DB_HOST: oci
        DB_NAME: XE
        DB_USERNAME: autotest
+       TEST_SUITE: php
 
      - PHP_VERSION: 7.1
        OC_VERSION: daily-stable10-qa
@@ -146,6 +244,7 @@ matrix:
        DB_NAME: oc_db
        DB_USERNAME: admin
        DB_PASSWORD: secret
+       TEST_SUITE: php
 
      - PHP_VERSION: 7.1
        OC_VERSION: daily-stable10-qa
@@ -154,3 +253,30 @@ matrix:
        DB_NAME: oc_db
        DB_USERNAME: admin
        DB_PASSWORD: secret
+       TEST_SUITE: php
+
+    # UI tests
+     - PHP_VERSION: 7.1
+       OC_VERSION: daily-stable10-qa
+       DB_TYPE: mysql
+       DB_HOST: mysqlmb4
+       DB_NAME: oc_db
+       DB_USERNAME: admin
+       DB_PASSWORD: secret
+       TEST_SUITE: acceptance
+       BEHAT_SUITE: webUISearchElastic
+       NEED_ELASTICSEARCH_SERVER: true
+       NEED_SERVER: true
+
+    # API tests
+     - PHP_VERSION: 7.1
+       OC_VERSION: daily-stable10-qa
+       DB_TYPE: mysql
+       DB_HOST: mysqlmb4
+       DB_NAME: oc_db
+       DB_USERNAME: admin
+       DB_PASSWORD: secret
+       TEST_SUITE: acceptance
+       BEHAT_SUITE: apiSearchElastic
+       NEED_ELASTICSEARCH_SERVER: true
+       NEED_SERVER: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 tests/unit/clover.xml
 vendor-bin/**/vendor
 vendor-bin/**/composer.lock
+/tests/acceptance/output

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -1,0 +1,35 @@
+default:
+  autoload:
+     '': %paths.base%/../features/bootstrap
+
+  suites:
+    webUISearchElastic:
+      paths:
+        - %paths.base%/../features/webUISearchElastic
+      contexts:
+        - SearchElasticContext:
+        - FeatureContext: &common_feature_context_params
+            baseUrl:  http://localhost:8080
+            adminUsername: admin
+            adminPassword: admin
+            regularUserPassword: 123456
+            ocPath: apps/testing/api/v1/occ
+        - WebUIGeneralContext:
+        - WebUILoginContext:
+        - WebUIUsersContext:
+        - WebUIFilesContext:
+        - WebUISearchContext:
+        - WebUIElasticSearchContext:
+
+    apiSearchElastic:
+      paths:
+        - %paths.base%/../features/apiSearchElastic
+      contexts:
+        - SearchElasticContext:
+        - FeatureContext: *common_feature_context_params
+        - SearchContext:
+
+  extensions:
+      jarnaiz\JUnitFormatter\JUnitFormatterExtension:
+          filename: report.xml
+          outputDir: %paths.base%/../output/

--- a/tests/acceptance/features/apiSearchElastic/search.feature
+++ b/tests/acceptance/features/apiSearchElastic/search.feature
@@ -1,0 +1,34 @@
+@api
+Feature: Search
+As a user
+I would like to be able to search for the content of files
+So that I can find needed files quickly
+
+  Background:
+    Given user "user0" has been created
+    And user "user0" has created a folder "/just-a-folder"
+    And user "user0" has created a folder "/फनी näme"
+    And user "user0" has uploaded file with content "files content" to "/upload.txt"
+    And user "user0" has uploaded file with content "does-not-matter" to "/a-image.png"
+    And user "user0" has uploaded file with content "file with content in subfolder" to "/just-a-folder/upload.txt"
+    And user "user0" has uploaded file with content "does-not-matter" to "/just-a-folder/a-image.png"
+    And user "user0" has uploaded file with content "more content" to "/just-a-folder/uploadÜठिF.txt"
+    And user "user0" has uploaded file with content "and one more content" to "/फनी näme/upload.txt"
+    And user "user0" has uploaded file with content "does-not-matter" to "/फनी näme/a-image.png"
+    And files of user "user0" have been indexed
+
+  Scenario Outline: search for files by pattern
+    Given using <dav_version> DAV path
+    When user "user0" searches for "content" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of "user0" should contain these files:
+      |/upload.txt                  |
+      |/just-a-folder/upload.txt    |
+      |/just-a-folder/uploadÜठिF.txt|
+      |/फनी näme/upload.txt    |
+    But the search result of "user0" should not contain these files:
+      |/a-image.png                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/bootstrap/SearchElasticContext.php
+++ b/tests/acceptance/features/bootstrap/SearchElasticContext.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <info@jankaritech.com>
+ * @copyright Copyright (c) 2018 Artur Neumann info@jankaritech.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use TestHelpers\SetupHelper;
+
+require_once 'bootstrap.php';
+
+/**
+ * Context for search elastic specific steps
+ */
+class SearchElasticContext implements Context {
+
+	/**
+	 * @var FeatureContext
+	 */
+	private $featureContext;
+
+	/**
+	 * @Given all files have been indexed
+	 * @Given files of user :user have been indexed
+	 * @When the administrator indexes all files
+	 * @When the administrator indexes files of user :user
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function indexFiles($user = null) {
+		if ($user === null) {
+			$user = '--all';
+		}
+		SetupHelper::runOcc(["search:index", $user]);
+		SetupHelper::resetOpcache(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword()
+		);
+	}
+
+	/**
+	 * @BeforeScenario
+	 *
+	 * @param BeforeScenarioScope $scope
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function setUpScenario(BeforeScenarioScope $scope) {
+		// Get the environment
+		$environment = $scope->getEnvironment();
+		// Get all the contexts you need in this context
+		$this->featureContext = $environment->getContext('FeatureContext');
+		SetupHelper::init(
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword(),
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getOcPath()
+		);
+	}
+}

--- a/tests/acceptance/features/bootstrap/WebUIElasticSearchContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIElasticSearchContext.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2018 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\MinkExtension\Context\RawMinkContext;
+use Page\ElasticSearchResultInOtherFoldersPage;
+use Page\SearchResultInOtherFoldersPage;
+use Page\OwncloudPage;
+use Behat\Gherkin\Node\PyStringNode;
+
+require_once 'bootstrap.php';
+
+/**
+ * WebUI Elastic Search context.
+ */
+class WebUIElasticSearchContext extends RawMinkContext implements Context {
+	/**
+	 *
+	 * @var SearchResultInOtherFoldersPage
+	 */
+	private $searchResultInOtherFoldersPage;
+	/**
+	 *
+	 * @var OwncloudPage
+	 */
+	private $ownCloudPage;
+
+	/**
+	 *
+	 * @var WebUIGeneralContext
+	 */
+	private $webUIGeneralContext;
+
+	/**
+	 *
+	 * @var WebUIFilesContext
+	 */
+	private $webUIFilesContext;
+
+	/**
+	 * WebUIElasticSearchContext constructor.
+	 *
+	 * @param OwncloudPage $ownCloudPage
+	 * @param ElasticSearchResultInOtherFoldersPage $searchResultInOtherFoldersPage
+	 */
+	public function __construct(
+		OwncloudPage $ownCloudPage,
+		ElasticSearchResultInOtherFoldersPage $searchResultInOtherFoldersPage
+	) {
+		$this->ownCloudPage = $ownCloudPage;
+		$this->searchResultInOtherFoldersPage = $searchResultInOtherFoldersPage;
+	}
+
+	/**
+	 * @Then /^the (?:file|folder) ((?:'[^']*')|(?:"[^"]*")) with the path ((?:'[^']*')|(?:"[^"]*")) should be listed in the search results in other folders section on the webUI with highlights containing:$/
+	 * @param string $fileName
+	 * @param string $path
+	 * @param PyStringNode $highlightsExpectations
+	 *
+	 * @return void
+	 */
+	public function fileShouldBeListedSearchResultOtherFolders(
+		$fileName, $path, PyStringNode $highlightsExpectations
+	) {
+		$fileName = \trim($fileName, $fileName[0]);
+		$path = \trim($path, $path[0]);
+		$this->webUIGeneralContext->setCurrentPageObject(
+			$this->searchResultInOtherFoldersPage
+		);
+		$this->webUIFilesContext->checkIfFileFolderIsListedOnTheWebUI(
+			$fileName, "should", "search results page", "", $path
+		);
+		$highlights = $this->searchResultInOtherFoldersPage->getHighlightsText(
+			$this->getSession(), $fileName, $path
+		);
+		PHPUnit_Framework_Assert::assertContains(
+			$highlightsExpectations->getRaw(), $highlights
+		);
+	}
+
+
+	/**
+	 * This will run before EVERY scenario.
+	 * It will set the properties for this object.
+	 *
+	 * @BeforeScenario @webUI
+	 *
+	 * @param BeforeScenarioScope $scope
+	 *
+	 * @return void
+	 */
+	public function before(BeforeScenarioScope $scope) {
+		// Get the environment
+		$environment = $scope->getEnvironment();
+		// Get all the contexts you need in this context
+		$this->webUIGeneralContext = $environment->getContext('WebUIGeneralContext');
+		$this->webUIFilesContext = $environment->getContext('WebUIFilesContext');
+	}
+}

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <info@jankaritech.com>
+ * @copyright Copyright (c) 2018 Artur Neumann info@jankaritech.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+require __DIR__ . '/../../../../../../lib/base.php';
+require __DIR__ . '/../../../../../../lib/composer/autoload.php';
+
+$classLoader = new \Composer\Autoload\ClassLoader();
+$classLoader->addPsr4(
+	"", __DIR__ . "/../../../../../../tests/acceptance/features/bootstrap", true
+);
+$classLoader->addPsr4("Page\\", __DIR__ . "/../lib", true);
+$classLoader->addPsr4(
+	"Page\\", __DIR__ . "/../../../../../../tests/acceptance/features/lib", true
+);
+$classLoader->addPsr4(
+	"TestHelpers\\", __DIR__ . "/../../../../../../tests/TestHelpers", true
+);
+
+$classLoader->register();

--- a/tests/acceptance/features/lib/ElasticSearchResultInOtherFoldersPage.php
+++ b/tests/acceptance/features/lib/ElasticSearchResultInOtherFoldersPage.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2018 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Page;
+
+use Behat\Mink\Session;
+use Page\FilesPageElement\FileRow;
+
+
+/**
+ * Page that shows the search results from other folders
+ * in the case of an elastic search.
+ */
+class ElasticSearchResultInOtherFoldersPage extends SearchResultInOtherFoldersPage {
+
+	/**
+	 * get the highlighted content of the file with a given name and path
+	 *
+	 * @param Session $session
+	 * @param string $fileName
+	 * @param string $path
+	 *
+	 * @return string
+	 */
+	public function getHighlightsText(Session $session, $fileName, $path) {
+		/**
+		 *
+		 * @var FileRow $fileRow
+		 */
+		$fileRow = $this->findFileRowByNameAndPath(
+			$fileName, $path, $session
+		);
+		return $fileRow->getHighlightsElement()->getText();
+	}
+}

--- a/tests/acceptance/features/webUISearchElastic/search.feature
+++ b/tests/acceptance/features/webUISearchElastic/search.feature
@@ -1,0 +1,31 @@
+@webUI @insulated @disablePreviews
+Feature: Search
+
+As a user
+I would like to be able to search for the content of files
+So that I can find needed files quickly
+
+  Background:
+    Given these users have been created:
+    |username|password|displayname|email       |
+    |user1   |1234    |User One   |u1@oc.com.np|
+    And files of user "user1" have been indexed
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "1234" using the webUI
+
+  Scenario: Simple search
+    When the user searches for "lorem" using the webUI
+    Then the file "lorem.txt" should be listed on the webUI
+    And the file "lorem-big.txt" should be listed on the webUI
+    And the file "lorem.txt" with the path "/simple-folder" should be listed in the search results in other folders section on the webUI
+    And the file "lorem-big.txt" with the path "/simple-folder" should be listed in the search results in other folders section on the webUI
+    And the file "lorem.txt" with the path "/0" should be listed in the search results in other folders section on the webUI
+    And the file "lorem.txt" with the path "/strängé नेपाली folder" should be listed in the search results in other folders section on the webUI
+    And the file "lorem-big.txt" with the path "/strängé नेपाली folder" should be listed in the search results in other folders section on the webUI
+
+  Scenario: Search content only
+    When the user searches for "lorem text" using the webUI
+    And the file "lorem.txt" with the path "/simple-folder" should be listed in the search results in other folders section on the webUI with highlights containing:
+      """
+      This is lorem text in the simple-folder.
+      """


### PR DESCRIPTION
a starting point for acceptance tests

to run this tests locally do:
1. clone app
1. run `make` in app folder
1. enable the app
1. as admin in the webUI in Settings->Search click "setup index" or run `occ search:reset`
1. run elastic-search server: `docker run -p 9200:9200 -p 9300:9300  owncloudci/elasticsearch` 
1. to run UI tests start selenium
1. from core/tests/acceptance run tests using `run.sh` as in every other app

known limitations:
1. in UI tests scrolling to files lower down the list will not work. for that the scrolling in `FilesPageBasic::findAllFileRowsByName()` need to be enhanced. Most likely by making `$this->appContentId` and `$this->appContentFilesContainerId` more flexible
1. as the scrolling does not work no results will be loaded that are not delivered in the first result