### PR TITLE
tests for group.nocontent setting

### DIFF
--- a/tests/acceptance/features/apiSearchElastic/limitAccessToGroups.feature
+++ b/tests/acceptance/features/apiSearchElastic/limitAccessToGroups.feature
@@ -14,7 +14,7 @@ So that the server is not overloaded
     And all files have been indexed
 
   @skip @issue-43
-  Scenario Outline: limit full text search to a certain group
+  Scenario Outline: limit search_elastic access to a group
     Given using <dav_version> DAV path
     When the administrator limits the access to search_elastic to "grp1"
     And all files have been indexed
@@ -32,6 +32,123 @@ So that the server is not overloaded
     And the search result of "user1" should contain these files:
       |/ownCloud.txt  |
     But the search result of "user1" should not contain these files:
+      |/textfile0.txt |
+      |/textfile1.txt |
+      |/textfile2.txt |
+      |/textfile3.txt |
+      |/textfile4.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: limit a group to only search in metadata
+    Given using <dav_version> DAV path
+    When the administrator disables the full text search for "grp1"
+    And user "user0" searches for "ownCloud" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of "user0" should contain these files:
+      |/ownCloud.txt  |
+    But the search result of "user0" should not contain these files:
+      |/textfile0.txt |
+      |/textfile1.txt |
+      |/textfile2.txt |
+      |/textfile3.txt |
+      |/textfile4.txt |
+    When user "user1" searches for "ownCloud" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of "user1" should contain these files:
+      |/ownCloud.txt  |
+      |/textfile0.txt |
+      |/textfile1.txt |
+      |/textfile2.txt |
+      |/textfile3.txt |
+      |/textfile4.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: limit a group to only search in metadata (reindex after limitation is set)
+    Given using <dav_version> DAV path
+    When the administrator disables the full text search for "grp1"
+    And the administrator indexes all files
+    And user "user0" searches for "ownCloud" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of "user0" should contain these files:
+      |/ownCloud.txt  |
+    And the search result of "user0" should not contain these files:
+      |/textfile0.txt |
+      |/textfile1.txt |
+      |/textfile2.txt |
+      |/textfile3.txt |
+      |/textfile4.txt |
+    When user "user1" searches for "ownCloud" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of "user1" should contain these files:
+      |/ownCloud.txt  |
+      |/textfile0.txt |
+      |/textfile1.txt |
+      |/textfile2.txt |
+      |/textfile3.txt |
+      |/textfile4.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: limit multiple groups to only search in metadata
+    Given using <dav_version> DAV path
+    And user "user2" has been created
+    And user "user2" has uploaded file with content "files content" to "/ownCloud.txt"
+    And group "grp2" has been created
+    And user "user2" has been added to group "grp2"
+    When the administrator disables the full text search for "grp1,grp2"
+    And the administrator indexes all files
+    And user "user0" searches for "ownCloud" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of "user0" should contain these files:
+      |/ownCloud.txt  |
+    But the search result of "user0" should not contain these files:
+      |/textfile0.txt |
+      |/textfile1.txt |
+      |/textfile2.txt |
+      |/textfile3.txt |
+      |/textfile4.txt |
+    When user "user2" searches for "ownCloud" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of "user2" should contain these files:
+      |/ownCloud.txt  |
+    But the search result of "user2" should not contain these files:
+      |/textfile0.txt |
+      |/textfile1.txt |
+      |/textfile2.txt |
+      |/textfile3.txt |
+      |/textfile4.txt |
+    When user "user1" searches for "ownCloud" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of "user1" should contain these files:
+      |/ownCloud.txt  |
+      |/textfile0.txt |
+      |/textfile1.txt |
+      |/textfile2.txt |
+      |/textfile3.txt |
+      |/textfile4.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: limit a group to only search in metadata, the searching user is member in a limited and also in an unlimited group
+    Given using <dav_version> DAV path
+    And group "grp2" has been created
+    And user "user0" has been added to group "grp2"
+    When the administrator disables the full text search for "grp1"
+    And user "user0" searches for "ownCloud" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of "user0" should contain these files:
+      |/ownCloud.txt  |
+    But the search result of "user0" should not contain these files:
       |/textfile0.txt |
       |/textfile1.txt |
       |/textfile2.txt |

--- a/tests/acceptance/features/bootstrap/SearchElasticContext.php
+++ b/tests/acceptance/features/bootstrap/SearchElasticContext.php
@@ -48,6 +48,7 @@ class SearchElasticContext implements Context {
 	 */
 	private $originalNoContentSetting = null;
 	private $originalGroupLimitSetting = null;
+	private $originalGroupNoContentSetting = null;
 
 	/**
 	 * @Given all files have been indexed
@@ -109,7 +110,8 @@ class SearchElasticContext implements Context {
 	}
 
 	/**
-	 * @Given the administrator limits the access to search_elastic to :group
+	 * @When the administrator limits the access to search_elastic to :group
+	 * @Given the administrator has limited the access to search_elastic to :group
 	 *
 	 * @param string $group
 	 * @return void
@@ -128,6 +130,30 @@ class SearchElasticContext implements Context {
 			$this->featureContext->getAdminUsername(),
 			$this->featureContext->getAdminPassword(),
 			"search_elastic", "group", $group
+		);
+	}
+
+	/**
+	* @When the administrator disables the full text search for :group
+	* @Given the administrator has disabled the full text search for :group
+	*
+	* @param string $group
+	* @return void
+	*/
+	public function disableFullTextSearchFor($group) {
+		if ($this->originalGroupNoContentSetting === null) {
+			$this->originalGroupNoContentSetting = AppConfigHelper::getAppConfig(
+				$this->featureContext->getBaseUrl(),
+				$this->featureContext->getAdminUsername(),
+				$this->featureContext->getAdminPassword(),
+				"search_elastic", "group.nocontent"
+				)['value'];
+		}
+		AppConfigHelper::modifyAppConfig(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword(),
+			"search_elastic", "group.nocontent", $group
 		);
 	}
 
@@ -163,7 +189,8 @@ class SearchElasticContext implements Context {
 	public function tearDownScenario(AfterScenarioScope $scope) {
 		$settings = [
 			"nocontent" => $this->originalNoContentSetting,
-			"group" => $this->originalGroupLimitSetting
+			"group" => $this->originalGroupLimitSetting,
+			"group.nocontent" => $this->originalGroupNoContentSetting
 		];
 		foreach ($settings as $configKey => $originalValue) {
 			if ($originalValue === ""


### PR DESCRIPTION
tests for "Limit a group to only search in metadata" https://github.com/owncloud/search_elastic#limit-a-group-to-only-search-in-metadata

issue: #35 