### PR TITLE
Do not pin coding-standard to PHP 5.6

### DIFF
--- a/vendor-bin/owncloud-codestyle/composer.json
+++ b/vendor-bin/owncloud-codestyle/composer.json
@@ -1,9 +1,4 @@
 {
-    "config" : {
-      "platform": {
-        "php": "5.6.37"
-      }
-    },
     "require": {
       "owncloud/coding-standard": "^1.0"
     }


### PR DESCRIPTION
It is not done in other "standard" app repos, and seems to have happened "accidentally" here when copied from somewhere.