### PR TITLE
Remove wrongly-named WebUIUsersContext

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -14,11 +14,11 @@ default:
             adminPassword: admin
             regularUserPassword: 123456
             ocPath: apps/testing/api/v1/occ
+        - WebUIElasticSearchContext:
+        - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
-        - WebUIFilesContext:
         - WebUISearchContext:
-        - WebUIElasticSearchContext:
 
     apiLimitSearches:
       paths:


### PR DESCRIPTION
When running webUI acceptance tests locally, ``behat`` told me that it did not know about ``WebUIUsersContext``. That is true, because that context in core is called ``WebUIUserContext``

I have no idea why ``behat`` does not complain about this in drone. Anyway the steps in ``WebUIUserContext`` are not needed anyway.

While touching this, sort the contexts so it is easier to look through the list.