### PR TITLE
Fix Mapper Insert method

### DIFF
--- a/db/statusmapper.php
+++ b/db/statusmapper.php
@@ -125,7 +125,6 @@ class StatusMapper extends Mapper {
 
 		$this->execute($sql, $params);
 
-		$entity->setFileId((int) $this->db->getInsertId($this->tableName));
 		return $entity;
 	}
 


### PR DESCRIPTION
## Bug
The Status Mappers insert method does not return the `fileid` of the entity.

## Problem
This sets all scanned files on `occ search:index --all` to Status "N" (New)

## Solution
Fix the mappers insert method