### PR TITLE
Forward Port Release 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.5.4]
+
+### Fixed
+- Fix Mapper Insert method [#75](https://github.com/owncloud/search_elastic/pull/75)
+
+## [0.5.3]
+Skipped
+
 ## [0.5.2]
 
 ### Fixed
@@ -30,7 +38,8 @@ This release requires Elastic Search 5.6.x and the `ingest-attachment` processor
 - Dropped support for Elastic Search 2.x
 
 
-[Unreleased]: https://github.com/owncloud/search_elastic/compare/v0.5.2..HEAD
+[Unreleased]: https://github.com/owncloud/search_elastic/compare/v0.5.4..HEAD
+[0.5.4]: https://github.com/owncloud/search_elastic/compare/v0.5.2...v0.5.4
 [0.5.2]: https://github.com/owncloud/search_elastic/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/owncloud/search_elastic/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/owncloud/search_elastic/compare/d1e94c0c7727b0eb73f62331eb52322ff8103824...v0.5.0

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -2,7 +2,7 @@
 <info>
 	<id>search_elastic</id>
 	<name>Elasticsearch</name>
-	<version>0.5.2</version>
+	<version>0.5.4</version>
 	<licence>Commercial</licence>
 	<author>ownCloud Inc.</author>
 	<dependencies>


### PR DESCRIPTION
This is the forward port of the 0.5.4 Release.
The 0.5.4 release could not be merged to master, because the branch reflects an earlier state before the php 5.6. related changes.