### PR TITLE
Fix delete statusmapper

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -109,11 +109,10 @@ return [
 	'suppress_issue_types' => [
 		'PhanTypeArraySuspicious',
 		'PhanDeprecatedFunction',
-		'PhanParamSignatureMismatch',
 		'PhanUnreferencedUseNormal',
-		'PhanTypeMismatchReturn',
 		'PhanTypeMismatchProperty',
 		'PhanUndeclaredClassMethod',
+		'PhanTypeMismatchReturn',
 		'PhanUndeclaredClassConstant',
 	]
 

--- a/lib/Db/StatusMapper.php
+++ b/lib/Db/StatusMapper.php
@@ -55,11 +55,13 @@ class StatusMapper extends Mapper {
 	/**
 	 * Deletes a status from the table
 	 * @param Entity $status the status that should be deleted
-	 * @return \PDOStatement the database query result
+	 * @return Entity the deleted entity
 	 */
 	public function delete(Entity $status) {
 		$sql = 'DELETE FROM `' . $this->tableName . '` WHERE `fileid` = ?';
-		return $this->execute($sql, [$status->getFileId()]);
+		$stmt = $this->execute($sql, [$status->getFileId()]);
+		$stmt->closeCursor();
+		return $status;
 	}
 	/**
 	 * Deletes a status from the table

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,8 +11,6 @@ parameters:
     - '#Call to an undefined method [a-zA-Z0-9\\_]+#'
     - '#Else branch is unreachable#'
     - '#Argument of an invalid type [a-zA-Z0-9\\_]+ supplied for foreach, only iterables are supported#'
-    - message: '#Return type \(PDOStatement\) of method.*#'
-      path: %currentWorkingDirectory%/lib/Db/StatusMapper.php
     - message: '#Method .* should return .* but returns.*#'
       path: %currentWorkingDirectory%/lib/Db/StatusMapper.php
     - message: '#OCA\\Encryption#'


### PR DESCRIPTION
Related to #90 

This has been changed to match the return type of `OCP\AppFramework\Db\Mapper::delete` which returns `Entity` instead of `PDOStatement` here.

See here: https://github.com/owncloud/core/blob/ffd65cb71849830ac5ce7dea40ca304ef9a037fb/lib/public/AppFramework/Db/Mapper.php#L76

Let's see what CI says. 

EDIT: CI passed. 