### PR TITLE
Remove mismatch type return on Status/Entity

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -111,7 +111,6 @@ return [
 		'PhanDeprecatedFunction',
 		'PhanUnreferencedUseNormal',
 		'PhanUndeclaredClassMethod',
-		'PhanTypeMismatchReturn',
 		'PhanUndeclaredClassConstant',
 	]
 

--- a/lib/Db/StatusMapper.php
+++ b/lib/Db/StatusMapper.php
@@ -179,7 +179,10 @@ class StatusMapper extends Mapper {
 			$columns . ' WHERE `fileid` = ?';
 		\array_push($params, $fileId);
 
-		return $this->execute($sql, $params);
+		$stmt = $this->execute($sql, $params);
+		$stmt->closeCursor();
+
+		return $entity;
 	}
 
 	/**
@@ -284,10 +287,12 @@ class StatusMapper extends Mapper {
 			WHERE `fileid` = ?
 		';
 		try {
-			return $this->findEntity($sql, [$fileId]);
+			$entity = $this->findEntity($sql, [$fileId]);
+			return new Status($fileId, $entity->getStatus());
 		} catch (DoesNotExistException $e) {
 			$status = new Status($fileId, Status::STATUS_NEW);
-			return $this->insert($status);
+			$this->insert($status);
+			return $status;
 		}
 	}
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,8 +11,6 @@ parameters:
     - '#Call to an undefined method [a-zA-Z0-9\\_]+#'
     - '#Else branch is unreachable#'
     - '#Argument of an invalid type [a-zA-Z0-9\\_]+ supplied for foreach, only iterables are supported#'
-    - message: '#Method .* should return .* but returns.*#'
-      path: %currentWorkingDirectory%/lib/Db/StatusMapper.php
     - message: '#OCA\\Encryption#'
       path: %currentWorkingDirectory%/lib/Jobs/UpdateContent.php
     - message: '#OCA\\Search_Elastic\\Search\\ElasticSearchResult.* does not call parent#'


### PR DESCRIPTION
Related to #99 

In #98, I replaced the use of some function parameters to take `Entity` instead of the `Status`, to make it consistent, and to avoid creating intermediate child object from the parent. This creates `Status` object from existing `Entity` objects. 

This is a parallel PR that solves the problem that #98 tries to as well, but I am not sure of returning `Status` from created `Entity` objects is correct, as during `save` on `Entity`, some changes might have been done.