### PR TITLE
Rename Build Command to create

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@
 		<admin>OCA\Search_Elastic\AdminPanel</admin>
 	</settings>
 	<commands>
-		<command>OCA\Search_Elastic\Command\Build</command>
+		<command>OCA\Search_Elastic\Command\Create</command>
 		<command>OCA\Search_Elastic\Command\Reset</command>
 		<command>OCA\Search_Elastic\Command\Update</command>
 		<command>OCA\Search_Elastic\Command\Rebuild</command>

--- a/lib/Command/Create.php
+++ b/lib/Command/Create.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class Build extends Command {
+class Create extends Command {
 
 	/**
 	 * @var IUserManager $userManager
@@ -56,7 +56,7 @@ class Build extends Command {
 	 */
 	protected function configure() {
 		$this
-			->setName('search:index:build')
+			->setName('search:index:create')
 			->setDescription('Create initial Search Index for one or all users. This command could not update the search index correctly after the initial indexing.')
 			->addArgument(
 				'user_id',

--- a/tests/acceptance/features/apiLimitSearches/indexOnlyMetadata.feature
+++ b/tests/acceptance/features/apiLimitSearches/indexOnlyMetadata.feature
@@ -18,7 +18,7 @@ So that I can use search_elastic only as a more scalable search on filenames
     And user "user0" has uploaded file "filesForUpload/simple.odt" to "/simple.odt"
     And user "user0" has uploaded file "filesForUpload/simple.pdf" to "/simple.pdf"
     And the administrator has configured the search_elastic app to index only metadata
-    And the search index has been built
+    And the search index has been created
 
   Scenario Outline: search for content
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiLimitSearches/limitAccessToGroups.feature
+++ b/tests/acceptance/features/apiLimitSearches/limitAccessToGroups.feature
@@ -13,7 +13,7 @@ So that the server is not overloaded
     And user "user1" has uploaded file with content "files content" to "/ownCloud.txt"
     And group "grp1" has been created
     And user "user0" has been added to group "grp1"
-    And the search index has been built
+    And the search index has been created
 
   Scenario Outline: limit search_elastic access to a group
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiSearchElastic/searchContent.feature
+++ b/tests/acceptance/features/apiSearchElastic/searchContent.feature
@@ -17,7 +17,7 @@ So that I can find needed files quickly
     And user "user0" has uploaded file with content "does-not-matter" to "/फन्नि näme/a-image.png"
     And user "user0" has uploaded file "filesForUpload/simple.odt" to "/simple.odt"
     And user "user0" has uploaded file "filesForUpload/simple.pdf" to "/simple.pdf"
-    And the search index has been built
+    And the search index has been created
 
   Scenario Outline: search for files by pattern
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiSearchElastic/searchSharedFiles.feature
+++ b/tests/acceptance/features/apiSearchElastic/searchSharedFiles.feature
@@ -17,7 +17,7 @@ So that I can find needed files quickly
     And user "user0" has uploaded file with content "does-not-matter" to "/फन्नि näme/a-image.png"
     And user "user0" has uploaded file "filesForUpload/simple.odt" to "/simple.odt"
     And user "user0" has uploaded file "filesForUpload/simple.pdf" to "/simple.pdf"
-    And the search index has been built
+    And the search index has been created
 
   Scenario Outline: user searches for files shared to him as a single user
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/bootstrap/SearchElasticContext.php
+++ b/tests/acceptance/features/bootstrap/SearchElasticContext.php
@@ -51,18 +51,18 @@ class SearchElasticContext implements Context {
 	private $originalGroupNoContentSetting = null;
 
 	/**
-	 * @Given the search index has been built
-	 * @Given the search index of user :user has been built
+	 * @Given the search index has been created
+	 * @Given the search index of user :user has been created
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 */
-	public function buildIndex($user = null) {
+	public function createIndex($user = null) {
 		if ($user === null) {
 			$user = '--all';
 		}
-		SetupHelper::runOcc(["search:index:build", $user]);
+		SetupHelper::runOcc(["search:index:create", $user]);
 		SetupHelper::resetOpcache(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getAdminUsername(),

--- a/tests/acceptance/features/webUISearchElastic/searchContent.feature
+++ b/tests/acceptance/features/webUISearchElastic/searchContent.feature
@@ -9,7 +9,7 @@ So that I can find needed files quickly
     Given these users have been created with skeleton files:
     |username|password|displayname|email       |
     |user1   |1234    |User One   |u1@oc.com.np|
-    And the search index has been built
+    And the search index has been created
     And the user has browsed to the login page
     And the user has logged in with username "user1" and password "1234" using the webUI
 

--- a/tests/acceptance/features/webUISearchElastic/searchSharedFiles.feature
+++ b/tests/acceptance/features/webUISearchElastic/searchSharedFiles.feature
@@ -9,7 +9,7 @@ So that I can find needed files quickly
     Given these users have been created with skeleton files:
     |username|password|displayname|email       |
     |user1   |1234    |User One   |u1@oc.com.np|
-    And the search index has been built
+    And the search index has been created
     And the user has browsed to the login page
     And the user has logged in with username "user1" and password "1234" using the webUI
 


### PR DESCRIPTION
## Description

Currently we have a occ command to create a fresh Search Index called `search:index:build`
Let's rename it.

Makes more sense  to have these commands
- `search:index:create`  Create the initial index
- `search:index:reset`  Resets the Search index
- `search:index:update` Runs the updateMetadata and UpdateContent Background Jobs
- `search:index:rebuild` Rebuilds the index for a single userid. Used for support etc.