### PR TITLE
Adding groups should not prohibit search for admin users

### DIFF
--- a/lib/Application.php
+++ b/lib/Application.php
@@ -147,7 +147,12 @@ class Application extends App {
 		$server = $this->getContainer()->getServer();
 		$config = $server->getConfig();
 		$group = $config->getAppValue(self::APP_ID, SearchElasticConfigService::ENABLED_GROUPS, null);
-		if (empty($group) || (
+		$isAdmin = false;
+		if ($server->getUserSession()->isLoggedIn()) {
+			$isAdmin = $server->getGroupManager()->isAdmin($server->getUserSession()->getUser()->getUID());
+		}
+
+		if (empty($group) || $isAdmin || (
 				$server->getUserSession()->getUser()
 				&& $server->getGroupManager()->isInGroup(
 					$server->getUserSession()->getUser()->getUID(), $group


### PR DESCRIPTION
When config app is set for a group, the admin users
shouldn't be prohibitted from the elastic search.

Signed-off-by: Sujith H <sharidasan@owncloud.com>