### PR TITLE
Use only 1 var in when matrix of drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -243,7 +243,6 @@ services:
       - MYSQL_ROOT_PASSWORD=secret
     when:
       matrix:
-        DB_TYPE: mysql
         DB_HOST: mysql
 
   mysqlmb4:
@@ -255,7 +254,6 @@ services:
       - MYSQL_ROOT_PASSWORD=secret
     when:
       matrix:
-        DB_TYPE: mysql
         DB_HOST: mysqlmb4
 
   pgsql:


### PR DESCRIPTION
The new drone tries to auto-convert the old drone format. It seems that when there are multiple variables mentioned in the `when` section of a step, it is doing something in the auto-conversion that causes:

`linter: duplicate step names`

I guess that it might be putting the step twice into the converted matrix.

The changes in this PR work-around the "feature".