### PR TITLE
Change ruflin/elastica to lowercase in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"issues": "https://github.com/owncloud/search_elastic/issues"
 	},
 	"require": {
-		"ruflin/Elastica": "^5.3.0"
+		"ruflin/elastica": "^5.3.0"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.2"

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "90a2e52e8074d67ac7155bdcb2cd546e",
+    "content-hash": "4c5b0104bbd0ef8c7db273fd4e2147e5",
     "packages": [
         {
             "name": "elasticsearch/elasticsearch",


### PR DESCRIPTION
composer gives messages like: https://drone.owncloud.com/owncloud/search_elastic/599/1/2
```
Deprecation warning: require.ruflin/Elastica is invalid, it should not contain uppercase characters. Please use ruflin/elastica instead. Make sure you fix this as Composer 2.0 will error.
```

Change it to be `ruflin/elastica` and then do `composer update`

Note: nothing really interesting happens to `composer.lock`, which is "a good thing" I suppose.