### PR TITLE
Dependencies for release

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -164,16 +164,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "bf73deb2b3b896a9d9c75f3f0d88185d2faa27e2"
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/bf73deb2b3b896a9d9c75f3f0d88185d2faa27e2",
-                "reference": "bf73deb2b3b896a9d9c75f3f0d88185d2faa27e2",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/446d54b4cb6bf489fc9d75f55843658e6f25d801",
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801",
                 "shasum": ""
             },
             "require": {
@@ -207,7 +207,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2019-10-25T08:06:51+00:00"
+            "time": "2019-11-01T11:05:21+00:00"
         },
         {
             "name": "react/promise",


### PR DESCRIPTION
Apply the dependency bumps from PR #145 to the `release-1.0.0` branch.

```
composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 3 updates, 0 removals
  - Updating psr/log (1.1.0 => 1.1.1): Loading from cache
  - Updating elasticsearch/elasticsearch (v5.3.2 => v5.4.0): Downloading (100%)         
  - Updating ruflin/elastica (5.3.5 => 5.3.6): Downloading (100%)         
Writing lock file
Generating autoload files
```
and
```
composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Updating psr/log (1.1.1 => 1.1.2): Loading from cache
Writing lock file
Generating autoload files
```
