### PR TITLE
Add php unit composer dependencies to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,12 +93,12 @@ clean-build:
 
 .PHONY: test-php-unit
 test-php-unit: ## Run php unit tests
-test-php-unit:
+test-php-unit:  $(composer_deps)
 	$(PHPUNIT) --configuration ./phpunit.xml --testsuite unit
 
 .PHONY: test-php-unit-dbg
 test-php-unit-dbg: ## Run php unit tests using phpdbg
-test-php-unit-dbg:
+test-php-unit-dbg:  $(composer_deps)
 	$(PHPUNITDBG) --configuration ./phpunit.xml --testsuite unit
 
 .PHONY: test-php-style


### PR DESCRIPTION
## Description
If I clone this repo and immediately `make test-php-unit` it dies. I first need to know to do `composer install` or some other `make` target that will install the composer dependencies.

Add the composer dependencies so that `make test-php-unit` will "just work"

(I noticed this when sorting out `Makefile` for the metrics app)

## How Has This Been Tested?
Local `make test-php-unit`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] tests only

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

