### PR TITLE
Fix: searchelastic timeout issue

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -75,6 +75,7 @@ config = {
 					'commands': [
 						'cd /var/www/owncloud/server',
 						'php occ config:app:set search_elastic servers --value elasticsearch',
+						'wait-for-it -t 60 elasticsearch:9200',
 						'php occ search:index:reset --force'
 					]
 				}

--- a/.drone.yml
+++ b/.drone.yml
@@ -1176,6 +1176,7 @@ steps:
   commands:
   - cd /var/www/owncloud/server
   - php occ config:app:set search_elastic servers --value elasticsearch
+  - wait-for-it -t 60 elasticsearch:9200
   - php occ search:index:reset --force
 
 - name: fix-permissions
@@ -1316,6 +1317,7 @@ steps:
   commands:
   - cd /var/www/owncloud/server
   - php occ config:app:set search_elastic servers --value elasticsearch
+  - wait-for-it -t 60 elasticsearch:9200
   - php occ search:index:reset --force
 
 - name: fix-permissions
@@ -1457,6 +1459,7 @@ steps:
   commands:
   - cd /var/www/owncloud/server
   - php occ config:app:set search_elastic servers --value elasticsearch
+  - wait-for-it -t 60 elasticsearch:9200
   - php occ search:index:reset --force
 
 - name: fix-permissions
@@ -1597,6 +1600,7 @@ steps:
   commands:
   - cd /var/www/owncloud/server
   - php occ config:app:set search_elastic servers --value elasticsearch
+  - wait-for-it -t 60 elasticsearch:9200
   - php occ search:index:reset --force
 
 - name: fix-permissions
@@ -1738,6 +1742,7 @@ steps:
   commands:
   - cd /var/www/owncloud/server
   - php occ config:app:set search_elastic servers --value elasticsearch
+  - wait-for-it -t 60 elasticsearch:9200
   - php occ search:index:reset --force
 
 - name: fix-permissions
@@ -1868,6 +1873,7 @@ steps:
   commands:
   - cd /var/www/owncloud/server
   - php occ config:app:set search_elastic servers --value elasticsearch
+  - wait-for-it -t 60 elasticsearch:9200
   - php occ search:index:reset --force
 
 - name: fix-permissions
@@ -1998,6 +2004,7 @@ steps:
   commands:
   - cd /var/www/owncloud/server
   - php occ config:app:set search_elastic servers --value elasticsearch
+  - wait-for-it -t 60 elasticsearch:9200
   - php occ search:index:reset --force
 
 - name: fix-permissions
@@ -2128,6 +2135,7 @@ steps:
   commands:
   - cd /var/www/owncloud/server
   - php occ config:app:set search_elastic servers --value elasticsearch
+  - wait-for-it -t 60 elasticsearch:9200
   - php occ search:index:reset --force
 
 - name: fix-permissions


### PR DESCRIPTION
### Description
This PR fixes ```elasticsearch``` docker image pull timeout issue. For more details check this issue: https://github.com/owncloud/search_elastic/issues/158
