### PR TITLE
[Tests-Only] Fix unit tests related to core issue 37358 and core PR 37103

### DIFF
--- a/tests/unit/Command/RebuildTest.php
+++ b/tests/unit/Command/RebuildTest.php
@@ -178,9 +178,9 @@ class RebuildTest extends TestCase {
 		$this->userManager
 			->method('get')
 			->will($this->returnValueMap([
-				[$uid, $this->user],
-				[$uid2, null],
-				[$uid3, null],
+				[$uid, false, $this->user],
+				[$uid2, false, null],
+				[$uid3, false, null],
 			]));
 		$this->rootFolder
 			->expects($this->once())


### PR DESCRIPTION
Part of issue https://github.com/owncloud/core/issues/37358

The signature of core `lib/private/User/Manager.php` `get()` changed to have a new 2nd parameter.
See core PR https://github.com/owncloud/core/pull/37103

Adjust unit tests so that the mocking of userManager matches the way that phpunit sees the calls. Even though the new parameter is optional (has a default value), phpunit sees the call happening with the parameter having been set to its default value `false`