### PR TITLE
[Tests-Only] Fix phpstan.neon after phpstan 0.12.33 release

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,13 +1,12 @@
 parameters:
-  bootstrap: %currentWorkingDirectory%/../../lib/base.php
-  autoload_directories:
-    - %currentWorkingDirectory%/appinfo/Migrations
+  bootstrapFiles:
+    - %currentWorkingDirectory%/../../lib/base.php
   excludes_analyse:
     - %currentWorkingDirectory%/appinfo/Migrations
     - %currentWorkingDirectory%/appinfo/routes.php
   ignoreErrors:
-    - '#Call to an undefined method OCP\\AppFramework\\Db\\Entity::getFileId()#'
-    - '#Call to an undefined method OCP\\Files\\Node::getContent()#'
+    - '#Call to an undefined method OCP\\AppFramework\\Db\\Entity::getFileId\(\)#'
+    - '#Call to an undefined method OCP\\Files\\Node::getContent\(\)#'
     - message: '#Method .* should return .* but returns.*#'
       path: %currentWorkingDirectory%/lib/Db/StatusMapper.php
     - message: '#OCA\\Encryption#'


### PR DESCRIPTION
https://drone.owncloud.com/owncloud/search_elastic/1109/2/5
```
php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan analyse --memory-limit=4G --configuration=./phpstan.neon --no-progress --level=5 appinfo lib
⚠️  You're using a deprecated config option autoload_directories. ⚠️️

You might not need it anymore - try removing it from your
configuration file and run PHPStan again.

If the analysis fails, replace it with scanDirectories.

Read more about this in PHPStan's documentation:
https://phpstan.org/user-guide/discovering-symbols

⚠️  You're using a deprecated config option bootstrap. ⚠️️

This option has been replaced with bootstrapFiles which accepts a list of files
to execute before the analysis.

 -- ------------------------------------------------------------------------- 
     Error                                                                    
 -- ------------------------------------------------------------------------- 
     Ignored error #Call to an undefined method                               
     OCP\\AppFramework\\Db\\Entity::getFileId()# has an unescaped '()' which  
     leads to ignoring all errors. Use '\(\)' instead.                        
     Ignored error #Call to an undefined method                               
     OCP\\Files\\Node::getContent()# has an unescaped '()' which leads to     
     ignoring all errors. Use '\(\)' instead.                                 
 -- ------------------------------------------------------------------------- 

 [ERROR] Found 2 errors                                              
```

phpstan https://github.com/phpstan/phpstan/releases/tag/0.12.33 now reports what is actually a problem in `phpstan.neon`

Fix it and also:
- adjust deprecated `bootstrap` config option.

