### PR TITLE
[Feature] make Search more greedy

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -309,7 +309,7 @@ def phpstan(ctx):
         return pipelines
 
     default = {
-        "phpVersions": ["7.3"],
+        "phpVersions": ["7.4"],
         "logLevel": "2",
         "extraApps": {},
         "enableApp": True,

--- a/lib/Search/ElasticSearchProvider.php
+++ b/lib/Search/ElasticSearchProvider.php
@@ -30,7 +30,7 @@ namespace OCA\Search_Elastic\Search;
 use Elastica\Query;
 use Elastica\Query\BoolQuery;
 use Elastica\Query\MatchQuery;
-use Elastica\Query\SimpleQueryString;
+use Elastica\Query\QueryString;
 use OCA\Search_Elastic\AppInfo\Application;
 use OCA\Search_Elastic\SearchElasticConfigService;
 use OCA\Search_Elastic\SearchElasticService;
@@ -175,13 +175,14 @@ class ElasticSearchProvider extends PagedProvider {
 		$es_bool = new BoolQuery();
 		$es_bool->addFilter($es_filter);
 		if ($searchContent) {
-			$es_content_query = new SimpleQueryString($this->formatContentQuery($query));
+			$es_content_query = new QueryString($this->formatContentQuery($query));
 			$es_content_query->setFields(["file.content"]);
 			$es_content_query->setParam("analyze_wildcard", true);
 			$es_bool->addShould($es_content_query);
 		}
-		$es_metadata_query = new SimpleQueryString($query . "*");
+		$es_metadata_query = new QueryString($query . "*");
 		$es_metadata_query->setFields(["name"]);
+		$es_metadata_query->setParam("analyze_wildcard", true);
 		$es_bool->addShould($es_metadata_query);
 		$es_bool->setMinimumShouldMatch(1);
 

--- a/lib/Search/ElasticSearchProvider.php
+++ b/lib/Search/ElasticSearchProvider.php
@@ -180,9 +180,9 @@ class ElasticSearchProvider extends PagedProvider {
 			$es_content_query->setParam("analyze_wildcard", true);
 			$es_bool->addShould($es_content_query);
 		}
+
 		$es_metadata_query = new QueryString($query . "*");
 		$es_metadata_query->setFields(["name"]);
-		$es_metadata_query->setParam("analyze_wildcard", true);
 		$es_bool->addShould($es_metadata_query);
 		$es_bool->setMinimumShouldMatch(1);
 
@@ -209,7 +209,7 @@ class ElasticSearchProvider extends PagedProvider {
 		// only add wildcards if no search syntax given
 		if (!\preg_match('/\+|-|\*|\?|\||Ñ|\(|\)|\"/u', $query)) {
 			foreach ($querySegments as $segment) {
-				$formattedQuery.= $segment . "* ";
+				$formattedQuery.= "$segment* ";
 			}
 			return \trim($formattedQuery, " ");
 		}

--- a/lib/Search/ElasticSearchProvider.php
+++ b/lib/Search/ElasticSearchProvider.php
@@ -30,6 +30,7 @@ namespace OCA\Search_Elastic\Search;
 use Elastica\Query;
 use Elastica\Query\BoolQuery;
 use Elastica\Query\MatchQuery;
+use Elastica\Query\SimpleQueryString;
 use OCA\Search_Elastic\AppInfo\Application;
 use OCA\Search_Elastic\SearchElasticConfigService;
 use OCA\Search_Elastic\SearchElasticService;
@@ -173,23 +174,44 @@ class ElasticSearchProvider extends PagedProvider {
 
 		$es_bool = new BoolQuery();
 		$es_bool->addFilter($es_filter);
-		// wildcard queries are not analyzed, so ignore case. See http://stackoverflow.com/a/17280591
-		$loweredQuery = \strtolower($query);
 		if ($searchContent) {
-			$es_bool->addShould(new Query\MatchPhrasePrefix('file.content', $loweredQuery));
+			$es_content_query = new SimpleQueryString($this->formatContentQuery($query));
+			$es_content_query->setFields(["file.content"]);
+			$es_content_query->setParam("analyze_wildcard", true);
+			$es_bool->addShould($es_content_query);
 		}
-		$es_bool->addShould(new Query\MatchPhrasePrefix('name', $loweredQuery));
+		$es_metadata_query = new SimpleQueryString($query . "*");
+		$es_metadata_query->setFields(["name"]);
+		$es_bool->addShould($es_metadata_query);
 		$es_bool->setMinimumShouldMatch(1);
 
 		$es_query = new Query($es_bool);
 		$es_query->setHighlight([
 			'fields' => [
-				'file.content' => new \stdClass,
+				'file.content' => new \stdClass
 			],
 		]);
 
 		$es_query->setSize($size);
 		$es_query->setFrom(($page - 1) * $size);
 		return $this->searchElasticService->search($es_query);
+	}
+
+	/**
+	 * @param string $query
+	 *
+	 * @return string
+	 */
+	public function formatContentQuery($query) {
+		$querySegments = \explode(" ", $query);
+		$formattedQuery = "";
+		// only add wildcards if no search syntax given
+		if (!\preg_match('/\+|-|\*|\?|\||Ñ|\(|\)|\"/u', $query)) {
+			foreach ($querySegments as $segment) {
+				$formattedQuery.= $segment . "* ";
+			}
+			return \trim($formattedQuery, " ");
+		}
+		return $query;
 	}
 }

--- a/tests/acceptance/features/apiLimitSearches/indexOnlyMetadata.feature
+++ b/tests/acceptance/features/apiLimitSearches/indexOnlyMetadata.feature
@@ -79,10 +79,9 @@ Feature: index only metadata
   @issue-40
   Scenario Outline: search for filename (not full word - start of filename missing)
     Given using <dav_version> DAV path
-    When user "Alice" searches for "ad.txt" using the WebDAV API
+    When user "Alice" searches for "*ad.txt" using the WebDAV API
     Then the HTTP status code should be "207"
-    #And the search result of user "Alice" should contain these files:
-    And the search result of user "Alice" should not contain these files:
+    And the search result of user "Alice" should contain these files:
       | /upload.txt               |
       | /just-a-folder/upload.txt |
       | /फन्नि näme/upload.txt    |
@@ -98,15 +97,13 @@ Feature: index only metadata
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "does-not-matter" to "/a-png-file.txt"
     And the search index has been updated
-    When user "Alice" searches for ".png" using the WebDAV API
+    When user "Alice" searches for "*.png" using the WebDAV API
     Then the HTTP status code should be "207"
-    #And the search result of user "Alice" should contain these files:
-    And the search result of user "Alice" should not contain these files:
+    And the search result of user "Alice" should contain these files:
       | /a-image.png               |
       | /just-a-folder/a-image.png |
       | /फन्नि näme/a-image.png    |
-    #But the search result of user "Alice" should not contain these files:
-    But the search result of user "Alice" should contain these files:
+    But the search result of user "Alice" should not contain these files:
       | /a-png-file.txt |
     Examples:
       | dav_version |
@@ -116,10 +113,9 @@ Feature: index only metadata
   @issue-40
   Scenario Outline: search for filename (not full word - only middle part of filename given)
     Given using <dav_version> DAV path
-    When user "Alice" searches for "oad" using the WebDAV API
+    When user "Alice" searches for "*oad*" using the WebDAV API
     Then the HTTP status code should be "207"
-    #And the search result of user "Alice" should contain these files:
-    And the search result of user "Alice" should not contain these files:
+    And the search result of user "Alice" should contain these files:
       | /upload.txt                   |
       | /just-a-folder/upload.txt     |
       | /just-a-folder/uploadÜठिF.txt |
@@ -141,10 +137,10 @@ Feature: index only metadata
       | dav_version | filename   | search  |
       | old         | /000       | "000"   |
       | new         | /000       | "000"   |
-      | old         | /000       | "  0"   |
-      | new         | /000       | "  0"   |
-      | old         | /text -1 t | " -1"   |
-      | new         | /text -1 t | " -1"   |
+      | old         | /000       | "*0"   |
+      | new         | /000       | "0"   |
+      | old         | /text -1 t | "*-1"   |
+      | new         | /text -1 t | "*-1"   |
       | old         | /false     | "false" |
       | new         | /false     | "false" |
       | old         | /null      | "null"  |

--- a/tests/acceptance/features/apiLimitSearches/indexOnlyMetadata.feature
+++ b/tests/acceptance/features/apiLimitSearches/indexOnlyMetadata.feature
@@ -38,12 +38,12 @@ Feature: index only metadata
 
   Scenario Outline: search for filename
     Given using <dav_version> DAV path
-    When user "Alice" searches for "a-image.png" using the WebDAV API
+    When user "Alice" searches for "upload.txt" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result of user "Alice" should contain these files:
-      | /a-image.png               |
-      | /just-a-folder/a-image.png |
-      | /फन्नि näme/a-image.png    |
+      | /upload.txt               |
+      | /just-a-folder/upload.txt |
+      | /फन्नि näme/upload.txt      |
     Examples:
       | dav_version |
       | old         |
@@ -51,12 +51,12 @@ Feature: index only metadata
 
   Scenario Outline: search for filename (not exact case)
     Given using <dav_version> DAV path
-    When user "Alice" searches for "A-iMagE.png" using the WebDAV API
+    When user "Alice" searches for "UpLoAd.png" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result of user "Alice" should contain these files:
-      | /a-image.png               |
-      | /just-a-folder/a-image.png |
-      | /फन्नि näme/a-image.png    |
+      | /upload.txt               |
+      | /just-a-folder/upload.txt |
+      | /फन्नि näme/upload.txt      |
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/apiLimitSearches/indexOnlyMetadata.feature
+++ b/tests/acceptance/features/apiLimitSearches/indexOnlyMetadata.feature
@@ -51,7 +51,7 @@ Feature: index only metadata
 
   Scenario Outline: search for filename (not exact case)
     Given using <dav_version> DAV path
-    When user "Alice" searches for "UpLoAd.png" using the WebDAV API
+    When user "Alice" searches for "UpLoAd.txt" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result of user "Alice" should contain these files:
       | /upload.txt               |
@@ -76,7 +76,7 @@ Feature: index only metadata
       | old         |
       | new         |
 
-  @issue-40
+
   Scenario Outline: search for filename (not full word - start of filename missing)
     Given using <dav_version> DAV path
     When user "Alice" searches for "*ad.txt" using the WebDAV API
@@ -92,7 +92,7 @@ Feature: index only metadata
       | old         |
       | new         |
 
-  @issue-40
+
   Scenario Outline: search for filename (just file extension)
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "does-not-matter" to "/a-png-file.txt"
@@ -110,7 +110,7 @@ Feature: index only metadata
       | old         |
       | new         |
 
-  @issue-40
+
   Scenario Outline: search for filename (not full word - only middle part of filename given)
     Given using <dav_version> DAV path
     When user "Alice" searches for "*oad*" using the WebDAV API
@@ -137,10 +137,8 @@ Feature: index only metadata
       | dav_version | filename   | search  |
       | old         | /000       | "000"   |
       | new         | /000       | "000"   |
-      | old         | /000       | "*0"   |
-      | new         | /000       | "0"   |
-      | old         | /text -1 t | "*-1"   |
-      | new         | /text -1 t | "*-1"   |
+      | old         | /000       | "*0"    |
+      | new         | /000       | "*0"    |
       | old         | /false     | "false" |
       | new         | /false     | "false" |
       | old         | /null      | "null"  |

--- a/tests/acceptance/features/apiSearchElastic/searchContent.feature
+++ b/tests/acceptance/features/apiSearchElastic/searchContent.feature
@@ -94,8 +94,7 @@ Feature: Search for content
     Given using <dav_version> DAV path
     When user "Alice" searches for "Cloud" using the WebDAV API
     Then the HTTP status code should be "207"
-    #And the search result of user "Alice" should contain these files:
-    And the search result of user "Alice" should not contain these files:
+    And the search result of user "Alice" should contain these files:
       | /textfile0.txt          |
       | /textfile1.txt          |
       | /textfile2.txt          |
@@ -122,8 +121,7 @@ Feature: Search for content
     Given using <dav_version> DAV path
     When user "Alice" searches for "wnClo" using the WebDAV API
     Then the HTTP status code should be "207"
-    #And the search result of user "Alice" should contain these files:
-    And the search result of user "Alice" should not contain these files:
+    And the search result of user "Alice" should contain these files:
       | /textfile0.txt          |
       | /textfile1.txt          |
       | /textfile2.txt          |

--- a/tests/acceptance/features/apiSearchElastic/searchContent.feature
+++ b/tests/acceptance/features/apiSearchElastic/searchContent.feature
@@ -89,10 +89,10 @@ Feature: Search for content
       | old         |
       | new         |
 
-  @issue-38
+
   Scenario Outline: search for files by pattern (not full word - start of word missing)
     Given using <dav_version> DAV path
-    When user "Alice" searches for "Cloud" using the WebDAV API
+    When user "Alice" searches for "*Cloud" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result of user "Alice" should contain these files:
       | /textfile0.txt          |
@@ -116,10 +116,34 @@ Feature: Search for content
       | old         |
       | new         |
 
-  @issue-38
+
+  Scenario Outline: search for files with multiple words
+    Given using <dav_version> DAV path
+    When user "Alice" searches for "ownCloud text" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of user "Alice" should contain these files:
+      | /textfile0.txt          |
+      | /textfile1.txt          |
+      | /textfile2.txt          |
+      | /textfile3.txt          |
+      | /textfile4.txt          |
+      | /PARENT/CHILD/child.txt |
+      | /PARENT/parent.txt      |
+    But the search result of user "Alice" should not contain these files:
+      | /a-image.png                  |
+      | /upload.txt                   |
+      | /just-a-folder/upload.txt     |
+      | /just-a-folder/uploadÜठिF.txt |
+      | /फन्नि näme/upload.txt        |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+
   Scenario Outline: search for files by pattern (not full word - only middle part of word given)
     Given using <dav_version> DAV path
-    When user "Alice" searches for "wnClo" using the WebDAV API
+    When user "Alice" searches for "*wnClo*" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result of user "Alice" should contain these files:
       | /textfile0.txt          |

--- a/tests/acceptance/features/apiSearchElastic/searchSharedFiles.feature
+++ b/tests/acceptance/features/apiSearchElastic/searchSharedFiles.feature
@@ -274,7 +274,7 @@ Feature: Search for content
       | Carol    |
     And user "Alice" has shared folder "just-a-folder" with user "Brian"
     And user "Brian" has shared folder "just-a-folder" with user "Carol"
-    When user "Carol" uploads file with content "files with changed content" to "/just-a-folder/upload.txt" using the WebDAV API
+    When user "Carol" uploads file with content "files with a change of content" to "/just-a-folder/upload.txt" using the WebDAV API
     And the search index has been updated
     And user "Alice" searches for "change" using the WebDAV API
     Then the HTTP status code should be "207"

--- a/tests/acceptance/features/apiSearchElastic/searchWildcard.feature
+++ b/tests/acceptance/features/apiSearchElastic/searchWildcard.feature
@@ -20,7 +20,7 @@ Feature: Search for content using wildcard in query
   Scenario Outline: search using wildcard pattern at the end of string
     Given using <dav_version> DAV path
     And the search index has been updated
-    When user "Alice" searches for "foo *" using the WebDAV API
+    When user "Alice" searches for "foo*" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result of user "Alice" should contain only these files:
       | /file1.txt |
@@ -53,7 +53,7 @@ Feature: Search for content using wildcard in query
   Scenario Outline: search using wildcard pattern in the beginning of string
     Given using <dav_version> DAV path
     And the search index has been updated
-    When user "Alice" searches for "* baz" using the WebDAV API
+    When user "Alice" searches for "*baz" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result of user "Alice" should contain only these files:
       | /file3.txt |
@@ -65,12 +65,17 @@ Feature: Search for content using wildcard in query
       | old         |
       | new         |
 
-  Scenario Outline: search using wildcard pattern in the middle of string
+
+  Scenario Outline: search using wildcard pattern only
     Given using <dav_version> DAV path
     And the search index has been updated
-    When user "Alice" searches for "foo * baz" using the WebDAV API
+    When user "Alice" searches for "*" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the search result of user "Alice" should contain only these files:
+    And the search result of user "Alice" should contain these files:
+      | /file1.txt |
+      | /file2.txt |
+      | /file3.txt |
+      | /file4.txt |
       | /simple-folder/file5.txt |
       | /simple-folder/file6.txt |
       | /simple-search-folder/file7.txt |
@@ -79,26 +84,16 @@ Feature: Search for content using wildcard in query
       | old         |
       | new         |
 
-  Scenario Outline: search using wildcard pattern only
-    Given using <dav_version> DAV path
-    And the search index has been updated
-    When user "Alice" searches for "*" using the WebDAV API
-    Then the HTTP status code should be "207"
-    And the search result of user "Alice" should not contain any files
-      | dav_version |
-      | old         |
-      | new         |
-    Examples:
-      | dav_version |
-      | old         |
-      | new         |
 
   Scenario Outline: search using multiple wildcard patterns
     Given using <dav_version> DAV path
     And the search index has been updated
-    When user "Alice" searches for "*foo*baz*" using the WebDAV API
+    When user "Alice" searches for "*foo* *baz*" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result of user "Alice" should contain only these files:
+      | /file1.txt |
+      | /file3.txt |
+      | /file4.txt |
       | /simple-folder/file5.txt |
       | /simple-folder/file6.txt |
       | /simple-search-folder/file7.txt |

--- a/tests/acceptance/features/webUISearchElastic/searchContent.feature
+++ b/tests/acceptance/features/webUISearchElastic/searchContent.feature
@@ -50,17 +50,16 @@ Feature: Search
       """
       Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore
       """
-  @issue-38
+
   Scenario: Search content only (not full word - start of word missing)
-    When the user searches for "psum" using the webUI
+    When the user searches for "*psum" using the webUI
     Then file "lorem.txt" with path "/simple-folder" should be listed in the search results in the other folders section on the webUI with highlights containing:
       """
       Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore
       """
 
-  @issue-38
   Scenario: Search content only (not full word - only middle part of word given)
-    When the user searches for "psu" using the webUI
+    When the user searches for "*psu*" using the webUI
     Then file "lorem.txt" with path "/simple-folder" should be listed in the search results in the other folders section on the webUI with highlights containing:
       """
       Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore

--- a/tests/acceptance/features/webUISearchElastic/searchContent.feature
+++ b/tests/acceptance/features/webUISearchElastic/searchContent.feature
@@ -30,6 +30,13 @@ Feature: Search
       Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore
       """
 
+  Scenario: Search content only more than one word
+    When the user searches for "lorem ipsum sit" using the webUI
+    Then file "lorem.txt" with path "/simple-folder" should be listed in the search results in the other folders section on the webUI with highlights containing:
+      """
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore
+      """
+
   Scenario: Search content only (not exact case)
     When the user searches for "iPsUM" using the webUI
     Then file "lorem.txt" with path "/simple-folder" should be listed in the search results in the other folders section on the webUI with highlights containing:
@@ -37,30 +44,27 @@ Feature: Search
       Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore
       """
 
-  Scenario: Search content only (not full word - end of word missing)
+  Scenario: Search content only (not full word)
     When the user searches for "ipsu" using the webUI
+    Then file "lorem.txt" with path "/simple-folder" should be listed in the search results in the other folders section on the webUI with highlights containing:
+      """
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore
+      """
+  @issue-38
+  Scenario: Search content only (not full word - start of word missing)
+    When the user searches for "psum" using the webUI
     Then file "lorem.txt" with path "/simple-folder" should be listed in the search results in the other folders section on the webUI with highlights containing:
       """
       Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore
       """
 
   @issue-38
-  Scenario: Search content only (not full word - start of word missing)
-    When the user searches for "psum" using the webUI
-    Then file "lorem.txt" with path "/simple-folder" should not be listed in the search results in the other folders section on the webUI
-    #Then file "lorem.txt" with path "/simple-folder" should be listed in the search results in the other folders section on the webUI with highlights containing:
-    #  """
-    #  This is lorem text in the simple-folder.
-    #  """
-
-  @issue-38
   Scenario: Search content only (not full word - only middle part of word given)
     When the user searches for "psu" using the webUI
-    Then file "lorem.txt" with path "/simple-folder" should not be listed in the search results in the other folders section on the webUI
-    #Then file "lorem.txt" with path "/simple-folder" should be listed in the search results in the other folders section on the webUI with highlights containing:
-    #  """
-    #  This is lorem text in the simple-folder.
-    #  """
+    Then file "lorem.txt" with path "/simple-folder" should be listed in the search results in the other folders section on the webUI with highlights containing:
+      """
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore
+      """
 
   Scenario: Search pattern matches filename of one file and content of others
     Given user "Brian" has uploaded file with content "content to search for" to "/new-file.txt"

--- a/tests/unit/lib/TestElasticSearchProvider.php
+++ b/tests/unit/lib/TestElasticSearchProvider.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @author Michael Barz <mbarz@owncloud.com>
+ *
+ * @copyright Copyright (c) 2021, ownCloud GmbH
+ * @license GPL-2.0
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+namespace OCA\Search_Elastic\Tests\Unit;
+
+use OCA\Search_Elastic\Search\ElasticSearchProvider;
+use Test\TestCase;
+
+class TestElasticSearchProvider extends TestCase {
+	/**
+	 * @var ElasticSearchProvider
+	 */
+	private $elasticSearchProvider;
+
+	/**
+	 * Set Up scenario
+	 */
+	public function setUp(): void {
+		$this->elasticSearchProvider = new ElasticSearchProvider([]);
+	}
+
+	/**
+	 * @return \string[][]
+	 */
+	public function provideQueries() {
+		return [
+			["test", "test*"],
+			["*test", "*test"],
+			["*test*", "*test*"],
+			["this is a test", "this* is* a* test*"],
+			["this is a +test", "this is a +test"],
+			["this is a -test", "this is a -test"],
+			["this is a-test", "this is a-test"],
+			["\"this is a test\"", "\"this is a test\""],
+			["this (is a test)", "this (is a test)"],
+			["this is a testÑ", "this is a testÑ"],
+			["this is a test?", "this is a test?"],
+			["apple | red", "apple | red"],
+		];
+	}
+
+	/**
+	 * Test that the query format is working as expected
+	 *
+	 * @dataProvider provideQueries
+	 * @param $query
+	 * @param $result
+	 */
+	public function testFormatQuery($query, $result) {
+		self::assertEquals($result, $this->elasticSearchProvider->formatContentQuery($query));
+	}
+}


### PR DESCRIPTION
# Modify the query

## Outline

We change the internal query language to craft together a query which uses every term as string with trailing wildcards *search_string*

A list of strings `lorem ipsu` will be sent so the server as => `lorem* ipsu*`.

Users are also able to set wildcards on their own, e.g. `*lorem* *ipsu*`.

will fix two long standing issues @pmaier1 @EParzefall @mmattel 

- #38 
- #40 