### PR TITLE
[full-ci] [tests-only] Fix intermittent test failures

### DIFF
--- a/tests/acceptance/features/bootstrap/SearchElasticContext.php
+++ b/tests/acceptance/features/bootstrap/SearchElasticContext.php
@@ -207,11 +207,9 @@ class SearchElasticContext implements Context {
 	/**
 	 * @AfterScenario
 	 *
-	 * @param AfterScenarioScope $scope
-	 *
 	 * @return void
 	 */
-	public function tearDownScenario(AfterScenarioScope $scope) {
+	public function tearDownScenario() {
 		$settings = [
 			"nocontent" => $this->originalNoContentSetting,
 			"group" => $this->originalGroupLimitSetting,

--- a/tests/acceptance/features/bootstrap/SearchElasticContext.php
+++ b/tests/acceptance/features/bootstrap/SearchElasticContext.php
@@ -99,6 +99,12 @@ class SearchElasticContext implements Context {
 			$this->featureContext->getAdminUsername(),
 			$this->featureContext->getAdminPassword()
 		);
+		// https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html
+		// Elasticsearch automatically refreshes shards that have changed every index.refresh_interval
+		// which defaults to one second.
+		// If we continue too quickly after updating then we could get search results
+		// that are based on stale data. So delay for 2 seconds to avoid intermittent test problems.
+		\sleep(2);
 	}
 
 	/**


### PR DESCRIPTION
Fixes issue #224 
```
		// https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html
		// Elasticsearch automatically refreshes shards that have changed every index.refresh_interval
		// which defaults to one second.
		// If we continue too quickly after updating then we could get search results
		// that are based on stale data. So delay for 2 seconds to avoid intermittent test problems.
```

Hopefully my comment is self-explanatory.

We could have some external parameter for tests that makes the code request an immediate refresh - but if we do that then we will not really be testing in a way that production sites will use. IMO it is better to leave the Elastic Search service doing its default refresh, and have the comment and delay in the test code.

The first commit just tidies up an unused parameter in test code. I did that in order to have a starting PR that demonstrated the intermittent failure.