### PR TITLE
[tests-only] Reduce sleep

### DIFF
--- a/tests/acceptance/features/bootstrap/SearchElasticContext.php
+++ b/tests/acceptance/features/bootstrap/SearchElasticContext.php
@@ -100,7 +100,7 @@ class SearchElasticContext implements Context {
 			$this->featureContext->getAdminPassword()
 		);
 		// wait to be more confident that the update has taken effect
-		\sleep(10);
+		\sleep(5);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/SearchElasticContext.php
+++ b/tests/acceptance/features/bootstrap/SearchElasticContext.php
@@ -207,11 +207,9 @@ class SearchElasticContext implements Context {
 	/**
 	 * @AfterScenario
 	 *
-	 * @param AfterScenarioScope $scope
-	 *
 	 * @return void
 	 */
-	public function tearDownScenario(AfterScenarioScope $scope) {
+	public function tearDownScenario() {
 		$settings = [
 			"nocontent" => $this->originalNoContentSetting,
 			"group" => $this->originalGroupLimitSetting,

--- a/tests/acceptance/features/bootstrap/SearchElasticContext.php
+++ b/tests/acceptance/features/bootstrap/SearchElasticContext.php
@@ -99,6 +99,8 @@ class SearchElasticContext implements Context {
 			$this->featureContext->getAdminUsername(),
 			$this->featureContext->getAdminPassword()
 		);
+		// wait to be more confident that the update has taken effect
+		\sleep(10);
 	}
 
 	/**


### PR DESCRIPTION
Only sleep for 5 seconds after updating the search index.

In PR #227 we have been sleeping for 10 seconds, and that seems to be reliable. 

Try only a 5 second sleep. (And I will think about how we can better know when the search index update really is ready)