### PR TITLE
[tests-only] [full-ci] Enable files_external app in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1667,8 +1667,8 @@ def installTestrunner(ctx, phpVersion, useBundledApp):
 def installExtraApps(phpVersion, extraApps):
     commandArray = []
     for app, command in extraApps.items():
-        commandArray.append("git clone https://github.com/owncloud/%s.git %s/apps/%s" % (app, dir["testrunner"], app))
-        commandArray.append("cp -r %s/apps/%s %s/apps/" % (dir["testrunner"], app, dir["server"]))
+        commandArray.append("ls %s/apps/%s || git clone https://github.com/owncloud/%s.git %s/apps/%s" % (dir["testrunner"], app, app, dir["testrunner"], app))
+        commandArray.append("ls %s/apps/%s || cp -r %s/apps/%s %s/apps/" % (dir["server"], app, dir["testrunner"], app, dir["server"]))
         if (command != ""):
             commandArray.append("cd %s/apps/%s" % (dir["server"], app))
             commandArray.append(command)

--- a/.drone.star
+++ b/.drone.star
@@ -54,6 +54,9 @@ config = {
                 "apiLimitSearches",
                 "apiSearchElastic",
             ],
+            "extraApps": {
+                "files_external": "",
+            },
         },
     },
     "defaults": {

--- a/tests/acceptance/features/apiLimitSearches/indexOnlyMetadata.feature
+++ b/tests/acceptance/features/apiLimitSearches/indexOnlyMetadata.feature
@@ -305,7 +305,7 @@ Feature: index only metadata
       | old         |
       | new         |
 
-  @local_storage
+  @local_storage @files_external-app-required
   Scenario Outline: search on local storage
     Given using <dav_version> DAV path
     And user "Alice" has moved file "/upload.txt" to "/local_storage/upload.txt"

--- a/tests/acceptance/features/apiSearchElastic/searchContent.feature
+++ b/tests/acceptance/features/apiSearchElastic/searchContent.feature
@@ -327,7 +327,7 @@ Feature: Search for content
       | old         |
       | new         |
 
-  @local_storage
+  @local_storage @files_external-app-required
   Scenario Outline: search on local storage
     Given using <dav_version> DAV path
     And user "Alice" has moved file "/upload.txt" to "/local_storage/upload.txt"


### PR DESCRIPTION
In the latest core master, the files_external app starts up disabled.
There are some search_elastic acceptance test scenarios that check elastic search behavior when files are on local storage. For those, we need the files_external app enabled.

This pipeline enables files_external in pipelines that need it.