### PR TITLE
[Fix] fixed debug message if nocontent is set

### DIFF
--- a/lib/SearchElasticService.php
+++ b/lib/SearchElasticService.php
@@ -338,7 +338,7 @@ class SearchElasticService {
 
 		if (!$this->config->shouldContentBeIncluded()) {
 			$this->logger->debug(
-				"indexNode: folder, skipping content extraction",
+				"indexNode: content should not be included, skipping content extraction",
 				['app' => 'search_elastic']
 			);
 			$extractContent = false;


### PR DESCRIPTION
Fixed the debug message if `nocontent` is set.