### PR TITLE
Retrieve only the mtime from elasticsearch

### DIFF
--- a/lib/Search/ElasticSearchProvider.php
+++ b/lib/Search/ElasticSearchProvider.php
@@ -193,6 +193,8 @@ class ElasticSearchProvider extends PagedProvider {
 			],
 		]);
 
+		// only the "mtime" field is being used at the moment
+		$es_query->setSource(['includes' => ['mtime']]);
 		$es_query->setSize($size);
 		$es_query->setFrom(($page - 1) * $size);
 		return $this->searchElasticService->search($es_query);


### PR DESCRIPTION
Retrieve only the mtime field from elasticsearch because it's the only field being used at the moment.

Related https://github.com/owncloud/enterprise/issues/5547