### PR TITLE
Ensure the users and groups are interpreted as a list

### DIFF
--- a/lib/SearchElasticService.php
+++ b/lib/SearchElasticService.php
@@ -537,7 +537,7 @@ class SearchElasticService {
 		// Include owner in list of users
 		$users[] = $ownerUser;
 
-		$result = ['users' => \array_unique($users), 'groups' => \array_unique($groups)];
+		$result = ['users' => \array_values(\array_unique($users)), 'groups' => \array_values(\array_unique($groups))];
 		$this->logger->debug(
 			"access to $path:" . \json_encode($result),
 			['app' => 'search_elastic']


### PR DESCRIPTION
There could be duplicated users or groups in those lists. The `array_unique` will remove the duplicates, but it might create holes in the list (removing the second item from a list of three) causing the list to be interpreted as a map when the data is sent to elasticsearch. This wrong interpretation causes elasticsearch to throw an error and the target file isn't indexed.

The PR fixes that scenario.

Ref: https://github.com/owncloud/enterprise/issues/5571