### PR TITLE
Always return an int from Symfony Command execute method

### DIFF
--- a/lib/Command/Create.php
+++ b/lib/Command/Create.php
@@ -111,9 +111,9 @@ class Create extends Command {
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
 	 *
-	 * @return int|null|void
+	 * @return int
 	 */
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		if ($input->getOption('all')) {
 			$users = $this->userManager->search('');
 		} else {
@@ -123,7 +123,7 @@ class Create extends Command {
 
 		if (\count($users) === 0) {
 			$output->writeln('<error>Please specify the user id to index, "--all" to index for all users</error>');
-			return;
+			return 1;
 		}
 
 		foreach ($users as $user) {
@@ -136,5 +136,6 @@ class Create extends Command {
 				$output->writeln("<error>Unknown user $user</error>");
 			}
 		}
+		return 0;
 	}
 }

--- a/lib/Command/Rebuild.php
+++ b/lib/Command/Rebuild.php
@@ -124,7 +124,7 @@ class Rebuild extends Command {
 	 *
 	 * @return int
 	 */
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$users = $input->getArgument('user_id');
 		$quiet = $input->getOption('quiet');
 
@@ -133,7 +133,7 @@ class Rebuild extends Command {
 			if ($userObject !== null) {
 				if ($this->shouldAbort($input, $output)) {
 					$output->writeln('Aborting.');
-					return -1;
+					return 1;
 				}
 				$this->rebuildIndex($userObject, $quiet, $output);
 			} else {

--- a/lib/Command/Reset.php
+++ b/lib/Command/Reset.php
@@ -78,7 +78,7 @@ class Reset extends Command {
 	 *
 	 * @return int
 	 */
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		if ($input->getOption('force')) {
 			$continue = true;
 		} else {

--- a/lib/Command/Update.php
+++ b/lib/Command/Update.php
@@ -85,7 +85,7 @@ class Update extends Command {
 	 *
 	 * @return int
 	 */
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$output->writeln("Start Updating the Elastic Search index:");
 
 		$updateJobs = [];


### PR DESCRIPTION
Symfony 5 will require this, so be prepared.
For Symfony 4 it is optional.

Preparation for https://github.com/owncloud/core/issues/39630