### PR TITLE
fix: drop usage of ${}

### DIFF
--- a/appinfo/Migrations/Version20170811212112.php
+++ b/appinfo/Migrations/Version20170811212112.php
@@ -31,7 +31,7 @@ class Version20170811212112 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 
-		if ($schema->hasTable("${prefix}search_elastic_status")) {
+		if ($schema->hasTable("{$prefix}search_elastic_status")) {
 			$table = $schema->getTable("{$prefix}search_elastic_status");
 
 			$fileIdColumn = $table->getColumn('fileid');

--- a/lib/Hooks/Files.php
+++ b/lib/Hooks/Files.php
@@ -248,7 +248,7 @@ class Files {
 			$node = $userFolder->get($params['path']);
 			self::processNode($node, $node->getOwner()->getUID());
 		} else {
-			\OC::$server->getLogger()->debug("Hook fileVersionRestoreUpdate could not find user: ${params['user']} revision in param "
+			\OC::$server->getLogger()->debug("Hook fileVersionRestoreUpdate could not find user: {$params['user']} revision in param "
 				. \json_encode($params), ['app' => 'search_elastic']);
 		}
 	}


### PR DESCRIPTION
## Description
In preparation of php8.2 support - see https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated

Similar to core https://github.com/owncloud/core/pull/40995
