### PR TITLE
fix: do not render search content highlights as HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### [Unreleased] 
 
+### Fixed
+
+* Content highlights of search results are no longer rendered as HTML, fixing a stored cross site scripting issue where file content could execute script in the session of a user the file was shared with
 
 ### [2.4.0] - 2023-11-02
 

--- a/js/search.js
+++ b/js/search.js
@@ -1,4 +1,46 @@
 (function() {
+	/**
+	 * Highlight fragments are built from attacker controlled file content, so they
+	 * must never be handed to .html(). Rebuild them from an inert document, keeping
+	 * text and the <em> markers elasticsearch wraps the matched terms in, and
+	 * dropping every other element together with its subtree.
+	 *
+	 * Stripping - not escaping - is deliberate: elasticsearch already encodes the
+	 * fragment ('encoder' => 'html'), escaping again here would show the encoded
+	 * entities to the user.
+	 *
+	 * @param {string} html highlight fragment
+	 * @param {Document} target document the returned nodes belong to
+	 * @returns {Array} sanitized nodes, ready to be appended
+	 */
+	function sanitizeHighlights(html, target) {
+		// parsing into a 'text/html' document is inert: no script is executed and
+		// no resource is loaded, unlike jQuery.parseHTML which builds the fragment
+		// against the live document
+		var parsed = new DOMParser().parseFromString(html, 'text/html');
+
+		function convert(node) {
+			var nodes = [];
+			for (var i = 0; i < node.childNodes.length; i++) {
+				var child = node.childNodes[i];
+				if (child.nodeType === Node.TEXT_NODE) {
+					nodes.push(target.createTextNode(child.nodeValue));
+				} else if (child.nodeType === Node.ELEMENT_NODE && child.tagName === 'EM') {
+					var em = target.createElement('em');
+					var grandChildren = convert(child);
+					for (var j = 0; j < grandChildren.length; j++) {
+						em.appendChild(grandChildren[j]);
+					}
+					nodes.push(em);
+				}
+				// anything else is dropped, subtree included
+			}
+			return nodes;
+		}
+
+		return convert(parsed.body);
+	}
+
 	OCA.Search.ElasticSearch = {
 		attach: function(search) {
 			search.setRenderer('search_elastic', OCA.Search.ElasticSearch.renderFileResult);
@@ -43,7 +85,8 @@
 			}
 			if ($fileResultRow && typeof result.highlights === 'object' && result.highlights !== null) {
 				var highlights = result.highlights.join(' … ');
-				var $highlightsDiv = $('<div class="highlights"></div>').html(highlights);
+				var $highlightsDiv = $('<div class="highlights"></div>')
+					.append(sanitizeHighlights(highlights, document));
 				$row.find('td.info div.path').after($highlightsDiv);
 			}
 			return $fileResultRow;

--- a/lib/Connectors/BaseConnector.php
+++ b/lib/Connectors/BaseConnector.php
@@ -369,6 +369,9 @@ abstract class BaseConnector implements IConnector {
 				],
 			],
 			'highlight' => [
+				// the fragment contains attacker controlled file content and is
+				// rendered as HTML by the consumers - let elasticsearch encode it
+				'encoder' => 'html',
 				'fields' => ['file.content' => new \stdClass]
 			],
 			'_source' => [

--- a/lib/Connectors/ConnectorLegacy.php
+++ b/lib/Connectors/ConnectorLegacy.php
@@ -86,6 +86,9 @@ class ConnectorLegacy extends BaseConnector {
 				],
 			],
 			'highlight' => [
+				// the fragment contains attacker controlled file content and is
+				// rendered as HTML by the consumers - let elasticsearch encode it
+				'encoder' => 'html',
 				'fields' => ['file.content' => new \stdClass]
 			],
 			'_source' => [

--- a/lib/Connectors/ConnectorRelevanceV2.php
+++ b/lib/Connectors/ConnectorRelevanceV2.php
@@ -297,6 +297,9 @@ class ConnectorRelevanceV2 extends BaseConnector {
 				],
 			],
 			'highlight' => [
+				// the fragment contains attacker controlled file content and is
+				// rendered as HTML by the consumers - let elasticsearch encode it
+				'encoder' => 'html',
 				'fields' => ['file.content' => new \stdClass]
 			],
 			'fields' => [

--- a/tests/acceptance/features/webUISearchElastic/searchContent.feature
+++ b/tests/acceptance/features/webUISearchElastic/searchContent.feature
@@ -87,6 +87,19 @@ Feature: Search
     But file "lorem.txt" should not be listed on the webUI
 
 
+  Scenario: content highlights are not rendered as markup
+    Given user "Brian" has uploaded file with content "qreport <script>alert(1)</script> tail" to "/xss-highlight.txt"
+    And the search index has been updated
+    And the user has reloaded the current page of the webUI
+    When the user searches for "qreport" using the webUI
+    # the payload has to show up as visible text - if it were rendered as markup
+    # the script element would not contribute any visible text at all
+    Then file "xss-highlight.txt" with path "/" should be listed in the search results in the other folders section on the webUI with highlights containing:
+      """
+      qreport <script>alert(1)</script> tail
+      """
+
+
   Scenario: search for files by UTF pattern
     Given user "Brian" has uploaded file with content "मेरो नेपालि content" to "/utf-upload.txt"
     And user "Brian" has uploaded file with content "मेरो दोस्रो नेपालि content" to "/simple-folder/utf-upload.txt"

--- a/tests/unit/Connectors/ConnectorLegacyTest.php
+++ b/tests/unit/Connectors/ConnectorLegacyTest.php
@@ -271,6 +271,7 @@ class ConnectorLegacyTest extends TestCase {
 				],
 			],
 			'highlight' => [
+				'encoder' => 'html',
 				'fields' => ['file.content' => new \stdClass]
 			],
 			'_source' => [
@@ -372,6 +373,7 @@ class ConnectorLegacyTest extends TestCase {
 				],
 			],
 			'highlight' => [
+				'encoder' => 'html',
 				'fields' => ['file.content' => new \stdClass]
 			],
 			'_source' => [
@@ -473,6 +475,7 @@ class ConnectorLegacyTest extends TestCase {
 				],
 			],
 			'highlight' => [
+				'encoder' => 'html',
 				'fields' => ['file.content' => new \stdClass]
 			],
 			'_source' => [
@@ -525,6 +528,60 @@ class ConnectorLegacyTest extends TestCase {
 		]);
 
 		$this->assertSame(['high light number 1', 'another high'], $this->connectorLegacy->findInResult($result, 'highlights'));
+	}
+
+	/**
+	 * findInResult is a deliberate passthrough: the highlight fragment is
+	 * HTML-encoded by elasticsearch itself (see the 'encoder' => 'html' setting
+	 * asserted in testFetchResultsHighlightUsesHtmlEncoder), not here. Encoding
+	 * again in PHP would also escape the <em> markers elasticsearch adds around
+	 * the matched terms and break highlighting.
+	 *
+	 * Consumers must therefore never render this value as HTML unencoded.
+	 */
+	public function testFindInResultHighlightIsPassedThroughVerbatim() {
+		$result = $this->createMock(Result::class);
+		$result->method('getHighlights')->willReturn([
+			'file.content' => ['<script>alert(1)</script>']
+		]);
+
+		$this->assertSame(
+			['<script>alert(1)</script>'],
+			$this->connectorLegacy->findInResult($result, 'highlights')
+		);
+	}
+
+	/**
+	 * The highlight fragment contains attacker-controlled file content. Without
+	 * an explicit encoder elasticsearch defaults to 'encoder: default', which
+	 * does not HTML-encode the content surrounding the matched terms, exposing
+	 * every consumer of the fragment to stored XSS.
+	 */
+	public function testFetchResultsHighlightUsesHtmlEncoder() {
+		$this->esConfig->method('getGroupNoContentArray')->willReturn([]);
+		$this->esConfig->method('shouldContentBeIncluded')->willReturn(true);
+
+		$userObj = $this->createMock(IUser::class);
+		$userObj->method('getUID')->willReturn('mockedUser');
+		$this->userManager->method('get')->willReturn($userObj);
+		$this->groupManager->method('getUserGroups')->willReturn([]);
+
+		$rawQuery = null;
+		$query = $this->createMock(Query::class);
+		$query->expects($this->once())
+			->method('setRawQuery')
+			->willReturnCallback(function ($q) use (&$rawQuery, &$query) {
+				$rawQuery = $q;
+				return $query;
+			});
+
+		$this->factory->method('getNewQuery')->willReturn($query);
+		$this->factory->method('getNewIndex')->willReturn($this->createMock(Index::class));
+		$this->factory->method('getNewSearch')->willReturn($this->createMock(Search::class));
+
+		$this->connectorLegacy->fetchResults('mockedUser', 'test query', 30, 0);
+
+		$this->assertSame('html', $rawQuery['highlight']['encoder'] ?? null);
 	}
 
 	public function testFindInResultMtime() {

--- a/tests/unit/Connectors/ConnectorRelevanceV2Test.php
+++ b/tests/unit/Connectors/ConnectorRelevanceV2Test.php
@@ -404,6 +404,7 @@ class ConnectorRelevanceV2Test extends TestCase {
 				],
 			],
 			'highlight' => [
+				'encoder' => 'html',
 				'fields' => ['file.content' => new \stdClass]
 			],
 			'fields' => [
@@ -563,6 +564,7 @@ class ConnectorRelevanceV2Test extends TestCase {
 				],
 			],
 			'highlight' => [
+				'encoder' => 'html',
 				'fields' => ['file.content' => new \stdClass]
 			],
 			'fields' => [
@@ -722,6 +724,7 @@ class ConnectorRelevanceV2Test extends TestCase {
 				],
 			],
 			'highlight' => [
+				'encoder' => 'html',
 				'fields' => ['file.content' => new \stdClass]
 			],
 			'fields' => [
@@ -777,6 +780,60 @@ class ConnectorRelevanceV2Test extends TestCase {
 		]);
 
 		$this->assertSame(['high light number 1', 'another high'], $this->connectorRelevanceV2->findInResult($result, 'highlights'));
+	}
+
+	/**
+	 * findInResult is a deliberate passthrough: the highlight fragment is
+	 * HTML-encoded by elasticsearch itself (see the 'encoder' => 'html' setting
+	 * asserted in testFetchResultsHighlightUsesHtmlEncoder), not here. Encoding
+	 * again in PHP would also escape the <em> markers elasticsearch adds around
+	 * the matched terms and break highlighting.
+	 *
+	 * Consumers must therefore never render this value as HTML unencoded.
+	 */
+	public function testFindInResultHighlightIsPassedThroughVerbatim() {
+		$result = $this->createMock(Result::class);
+		$result->method('getHighlights')->willReturn([
+			'file.content' => ['<script>alert(1)</script>']
+		]);
+
+		$this->assertSame(
+			['<script>alert(1)</script>'],
+			$this->connectorRelevanceV2->findInResult($result, 'highlights')
+		);
+	}
+
+	/**
+	 * The highlight fragment contains attacker-controlled file content. Without
+	 * an explicit encoder elasticsearch defaults to 'encoder: default', which
+	 * does not HTML-encode the content surrounding the matched terms, exposing
+	 * every consumer of the fragment to stored XSS.
+	 */
+	public function testFetchResultsHighlightUsesHtmlEncoder() {
+		$this->esConfig->method('getGroupNoContentArray')->willReturn([]);
+		$this->esConfig->method('shouldContentBeIncluded')->willReturn(true);
+
+		$userObj = $this->createMock(IUser::class);
+		$userObj->method('getUID')->willReturn('mockedUser');
+		$this->userManager->method('get')->willReturn($userObj);
+		$this->groupManager->method('getUserGroups')->willReturn([]);
+
+		$rawQuery = null;
+		$query = $this->createMock(Query::class);
+		$query->expects($this->once())
+			->method('setRawQuery')
+			->willReturnCallback(function ($q) use (&$rawQuery, &$query) {
+				$rawQuery = $q;
+				return $query;
+			});
+
+		$this->factory->method('getNewQuery')->willReturn($query);
+		$this->factory->method('getNewIndex')->willReturn($this->createMock(Index::class));
+		$this->factory->method('getNewSearch')->willReturn($this->createMock(Search::class));
+
+		$this->connectorRelevanceV2->fetchResults('mockedUser', 'test query', 30, 0);
+
+		$this->assertSame('html', $rawQuery['highlight']['encoder'] ?? null);
 	}
 
 	public function testFindInResultMtime() {


### PR DESCRIPTION
## Description

The content highlight of a search result is built from file content. It was passed to jQuery `.html()` in the result renderer, and the elasticsearch query did not set an `encoder`, so elasticsearch returned the fragment surrounding the matched terms unencoded. A user could therefore put markup into a file, share it, and have it run in the session of anyone who searched for a term in that file.

Two independent layers now prevent this, **either one of which stops the attack on its own**:

1. **Backend** — all three connectors request `'encoder' => 'html'`, so elasticsearch encodes the fragment. This also covers the other consumer of the value, the DAV `search-highlights` property.
2. **Frontend** — `js/search.js` no longer uses `.html()`. The fragment is parsed into an inert document (`DOMParser` with `text/html`, which executes no script and loads no resources, unlike `jQuery.parseHTML`) and rebuilt from text nodes, keeping only the `<em>` elements elasticsearch wraps the matched terms in and dropping every other element together with its subtree.

The second layer **strips rather than escapes** on purpose. The first layer already encodes the content, so escaping again would show the encoded entities to the user; and elasticsearch's own `<em>` markers have to stay real markup for highlighting to keep working.

## Related Issue

- Fixes OC10-124
- Companion PR (core, second egress channel): owncloud/core#41760

## Motivation and Context

Stored XSS reachable by any authenticated user against any user they can share a file with. Note the default CSP does not mitigate this: `'unsafe-inline'` is absent (so event-handler payloads are blocked) but `'unsafe-eval'` is present, and jQuery routes `<script`-bearing strings through `globalEval`.

## How Has This Been Tested?

- **test environment:** PHP 8.3.32, PHPUnit 9.6.35; sanitizer additionally exercised in headless Chromium against the vendored jQuery 2.1.4.
- **unit, backend:** `make test-php-unit` → OK, 163 tests / 369 assertions. New tests assert `encoder => html` is present in the built query for both connectors, and pin `findInResult` as a deliberate verbatim passthrough (encoding there would escape the `<em>` markers).
- **unit, style:** `make test-php-style` → 0 of 59 files to fix.
- **frontend, empirical:** the sanitizer was run verbatim in a headless browser over payload shapes (`<script>`, `<img onerror>`, `<svg onload>`, `<iframe srcdoc>`, `<em>` nested in a stripped element): 13/13 pass, **zero payloads executed**. The same harness run against the *old* `.html()` code scored 6/13 and **executed four payloads**, confirming the harness actually detects the bug.
- **no double-escaping:** with both layers live the payload renders as literal visible text with `<em>` highlighting intact and no `&lt;` on screen.
- **acceptance:** new scenario in `searchContent.feature` stores a payload and asserts it appears as *visible text* — if it were parsed as markup the script element would contribute no visible text at all.
- **not run:** the reporter's end-to-end PoC needs a live ES 7.17 + ingest-attachment instance, unavailable in this environment. The chain is verified layer-by-layer instead; the acceptance scenario covers it in CI.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [x] Changelog item

## Follow-ups (not in this PR)

- This repo has **no JS unit harness** (no karma/jest), which is why the sanitizer relies on acceptance coverage. Worth adding separately.
- Removing `'unsafe-eval'` from core's default CSP would kill this entire payload class, but risks breaking every app — separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
