### PR TITLE
chore: drop stale TODO about the acceptance workflow ref

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,10 +55,6 @@ jobs:
       app-name: ${{ needs.get-vars.outputs.app-name }}
       php-versions: ${{ needs.get-vars.outputs.php-versions }}
 
-  # TODO: switch both acceptance jobs back to @main once
-  # owncloud/reusable-workflows#88 is merged - the `elasticsearch-version` input
-  # only exists on that branch, and an unknown input to a reusable workflow is a
-  # startup failure that takes down every other job in this file too.
   acceptance-api:
     name: API acceptance tests
     needs:


### PR DESCRIPTION
## Description

Follow-up housekeeping from #349.

That PR temporarily pointed the two acceptance jobs at a branch of owncloud/reusable-workflows, because the `elasticsearch-version` input did not exist on `@main` yet, and left a `TODO` asking for them to be switched back once #88 merged.

#350 did the switch. Both jobs already reference `@main`, so the comment now contradicts the four lines directly beneath it — it reads as outstanding work when there is none. Removing it.

No functional change: the two `uses:` lines are untouched.

## How Has This Been Tested?

- `actionlint .github/workflows/main.yml` → zero findings
- YAML parses; both `uses:` refs confirmed still `@main`
- Diff is 4 deleted comment lines and nothing else

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [x] Changelog item — n/a, comment-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
